### PR TITLE
Show pickups by current day first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ yarn-debug.log*
 yarn-error.log*
 
 .idea/
+
+.eslintcache
+.firebase

--- a/package-lock.json
+++ b/package-lock.json
@@ -1821,6 +1821,8 @@
     },
     "@testing-library/jest-dom": {
       "version": "5.11.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
+      "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
@@ -1845,6 +1847,8 @@
     },
     "@testing-library/react": {
       "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.3.tgz",
+      "integrity": "sha512-BirBUGPkTW28ULuCwIbYo0y2+0aavHczBT6N9r3LrsswEW3pg25l1wgoE7I8QBIy1upXWkwKpYdWY7NYYP0Bxw==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^7.28.1"
@@ -1852,6 +1856,8 @@
     },
     "@testing-library/user-event": {
       "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.6.0.tgz",
+      "integrity": "sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==",
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
@@ -8603,6 +8609,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "luxon": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+      "integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -11066,6 +11077,8 @@
     },
     "react": {
       "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -11217,6 +11230,8 @@
     },
     "react-dom": {
       "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
+      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11240,6 +11255,8 @@
     },
     "react-scripts": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.1.tgz",
+      "integrity": "sha512-NnniMSC/wjwhcJAyPJCWtxx6CWONqgvGgV9+QXj1bwoW/JI++YF1eEf3Upf/mQ9KmP57IBdjzWs1XvnPq7qMTQ==",
       "requires": {
         "@babel/core": "7.12.3",
         "@pmmmwh/react-refresh-webpack-plugin": "0.4.2",
@@ -14149,7 +14166,9 @@
       }
     },
     "web-vitals": {
-      "version": "0.2.4"
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-0.2.4.tgz",
+      "integrity": "sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "bulma": "^0.9.1",
+    "luxon": "^1.25.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -46,7 +46,7 @@ const PickupCard = ({ field, day, time, address, contact }) => {
                                     <div className="level-item has-text-centered">
                                         <div>
                                             <p className="heading">Contact</p>
-                                            <p className="subtitle is-size-5-mobile">{contact || 'No contact'}</p>
+                                            <p className="subtitle is-size-5-mobile">{contact || 'N/A'}</p>
                                         </div>
                                     </div>
                                 </nav>


### PR DESCRIPTION
# What did I add?
I made it so that based on the current day in Denver, the games for that day are shown first, then the games for the next are shown right after, then other games shown in ascending order from Sunday -> Saturday.

# Why
Based on how people in the FB group typically ask for pickups happening on current day, this would make the site more friendly to its users in that sense.

# Screen capture
<img width="1440" alt="Screenshot 2021-01-28 at 5 26 49 PM" src="https://user-images.githubusercontent.com/13685735/106215367-0b6ee780-618e-11eb-93bb-5ae3be2549f8.png">

<img width="1440" alt="Screenshot 2021-01-28 at 5 27 18 PM" src="https://user-images.githubusercontent.com/13685735/106215396-19246d00-618e-11eb-8573-2471662600d6.png">


## When there are no pickups
<img width="1440" alt="Screenshot 2021-01-28 at 5 27 57 PM" src="https://user-images.githubusercontent.com/13685735/106215479-4f61ec80-618e-11eb-84e0-9fc6d4a030a6.png">
